### PR TITLE
fix: stop duplicating hero image in RSS/JSON feeds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ Personal blog. Built with [Anglesite](https://anglesite.dwk.io) (Astro 6 + Markd
 - `npm run lint:css` / `npm run lint:md` — stylelint / markdownlint (advisory)
 - `npm run deploy` — Build + pre-deploy security scan + `wrangler deploy` + WebSub ping + send webmentions
 
+## Worktrees
+
+Prefer a git worktree by default when starting any non-trivial change — a feature, a new post, or a multi-file edit — so work stays isolated from the main checkout. Use the harness's native worktree support, or `git worktree add ../pulletsforever-<branch> -b <branch>`. Each worktree is a fresh checkout with no `node_modules` (it isn't shared across worktrees), so run `npm install` in it before any `npm run build` / `npm test` / `npm run new-post`. Deploy from the main checkout after merging, not from a feature worktree.
+
 ## Architecture
 
 - **Pages and routes**: `src/pages/*.astro` (UI) and `src/pages/**/*.ts` (API endpoints — feeds, llms.txt, .well-known)

--- a/src/pages/feed.json.ts
+++ b/src/pages/feed.json.ts
@@ -29,7 +29,7 @@ export async function GET(context: APIContext) {
         id: postUrl,
         url: postUrl,
         title: post.data.title,
-        content_html: renderArticleForFeed(post, origin, heroUrl),
+        content_html: renderArticleForFeed(post, origin),
         date_published: rfc3339(post.data.publishDate),
         tags: filterTagList(post.data.tags),
       };

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -4,7 +4,6 @@
  */
 
 import type { APIContext } from "astro";
-import { getImage } from "astro:assets";
 import { getCollection } from "astro:content";
 import siteConfig from "../site.config.ts";
 import {
@@ -24,20 +23,16 @@ export async function GET(context: APIContext) {
     ? rfc3339(posts[0].data.publishDate)
     : rfc3339(new Date());
 
-  const entries = (
-    await Promise.all(
-      posts.map(async (post) => {
-        const postUrl = `${origin}/${post.id}/`;
-        const heroUrl = post.data.image
-          ? `${origin}${(await getImage({ src: post.data.image, format: "webp", width: 1200 })).src}`
-          : undefined;
-        const articleHtml = renderArticleForFeed(post, origin, heroUrl);
-        const tags = filterTagList(post.data.tags);
-        const categoryTags = tags
-          .map((tag) => `\t\t<category term="${escapeXml(tag)}"/>`)
-          .join("\n");
-        const published = rfc3339(post.data.publishDate);
-        return `\t<entry>
+  const entries = posts
+    .map((post) => {
+      const postUrl = `${origin}/${post.id}/`;
+      const articleHtml = renderArticleForFeed(post, origin);
+      const tags = filterTagList(post.data.tags);
+      const categoryTags = tags
+        .map((tag) => `\t\t<category term="${escapeXml(tag)}"/>`)
+        .join("\n");
+      const published = rfc3339(post.data.publishDate);
+      return `\t<entry>
 \t\t<title>${escapeXml(post.data.title)}</title>
 \t\t<link href="${postUrl}" rel="alternate" type="text/html"/>
 \t\t<id>${postUrl}</id>
@@ -45,9 +40,8 @@ export async function GET(context: APIContext) {
 \t\t<updated>${published}</updated>
 ${categoryTags ? categoryTags + "\n" : ""}\t\t<content type="html">${escapeXml(articleHtml)}</content>
 \t</entry>`;
-      }),
-    )
-  ).join("\n");
+    })
+    .join("\n");
 
   const xml = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="${siteConfig.language}">

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -43,11 +43,19 @@ export function absolutizeHtml(html: string, siteOrigin: string): string {
   );
 }
 
-/** Build a post's full article HTML for inclusion in a feed entry. */
+/**
+ * Build a post's full article HTML for inclusion in a feed entry.
+ *
+ * Mirrors the website (`[slug].astro`), which renders only the post
+ * body. The frontmatter `image` is metadata (og:image, JSON-LD,
+ * related-post tiles) — every post that wants a visible hero authors
+ * it as the first inline image in the body. We deliberately do NOT
+ * prepend a hero `<figure>` here: doing so duplicated the image, since
+ * the body already contains it.
+ */
 export function renderArticleForFeed(
   post: Post,
   siteOrigin: string,
-  heroUrl?: string,
 ): string {
   const body = absolutizeHtml(renderPostHtml(post), siteOrigin);
   // Posts with footnotes already include the "-dwk" signature inside
@@ -55,15 +63,7 @@ export function renderArticleForFeed(
   // before the footnote section). Footnote-less posts get it appended
   // here at the end.
   const hasFootnotes = /^\[\^[^\]]+\]:/m.test(post.body ?? "");
-  let html = "";
-  if (heroUrl) {
-    const img = absolutizeHtml(
-      `<img src="${heroUrl}" alt="${post.data.imageAlt ?? ""}">`,
-      siteOrigin,
-    );
-    html += `  <figure class="hero-image">\n    ${img}\n  </figure>\n`;
-  }
-  html += `  ${body}\n`;
+  let html = `  ${body}\n`;
   if (!hasFootnotes) {
     html += `  <p class="signature">-dwk</p>`;
   }


### PR DESCRIPTION
## Problem

Feed entries showed the hero image **twice** (see the Olivetti typewriter duplicated in the reader screenshot from the bug report). `renderArticleForFeed` prepended a `<figure>` synthesized from the frontmatter `image`, then rendered the post body — which already contains that same image as its first inline image.

## Root cause

The website's post page (`src/pages/[slug].astro`) renders **only the body** (`<Content />`); it never renders the frontmatter `image` inline. The frontmatter `image` is metadata (og:image, JSON-LD, related-post tiles). Every post with a visible hero authors it as the first inline image in the body — confirmed across all 17 posts with an `image:` frontmatter — so the feed's prepend was *always* a duplicate.

## Fix

Make the feeds mirror the website: render body + signature only.

- `src/utils/feed.ts` — drop the hero `<figure>` prepend (and the `heroUrl` param)
- `src/pages/feed.xml.ts` — remove unused `getImage`/`heroUrl`; simplify the now-synchronous entry map
- `src/pages/feed.json.ts` — stop injecting the hero into `content_html`; **keep** `item.image` (valid JSON Feed v1.1 per-item metadata for previews)
- `CLAUDE.md` — document the worktree workflow used for this change

## Verification

Clean rebuild (`rm -rf dist node_modules/.astro && npm run build`), checked the actual reported post:

- Atom `feed.xml`: olivetti image appears **once** (was twice) ✓
- JSON `feed.json`: image **once** in `content_html`, `item.image` metadata preserved ✓
- `npm run typecheck`: 0 errors ✓
- `npm test` (worker): 7/7 passing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)