### PR TITLE
chore(deploy): add Workers Builds CI deploy scripts (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,22 @@ Personal blog. Built with [Anglesite](https://anglesite.dwk.io) (Astro 6 + Markd
 - `npm run typecheck` — `astro check`
 - `npm test` — Worker tests (vitest, `--prefix worker`)
 - `npm run lint:css` / `npm run lint:md` — stylelint / markdownlint (advisory)
-- `npm run deploy` — Build + pre-deploy security scan + `wrangler deploy` + WebSub ping + send webmentions
+- `npm run deploy` — Manual laptop deploy: build + scan + `wrangler deploy` + WebSub ping + send webmentions (pings are fatal here so you notice failures interactively)
+- `npm run cloudflare:deploy` — Deploy command Cloudflare **Workers Builds** invokes in CI: `wrangler deploy` then `npm run notify`
+- `npm run notify` — Post-deploy pings, non-fatal (`websub:ping || true; webmentions:send || true`) so a transient hub error can't fail a CI build
+
+## Deploying
+
+Two paths, same Worker:
+
+- **Manual (laptop):** `npm run deploy` from `main`. Still available as a fallback / for ad-hoc deploys.
+- **CI (Cloudflare Workers Builds):** auto-builds + deploys on push once wired in the dashboard. Settings → Builds for the `pulletsforever-com` Worker:
+  - Build command: `npm run build && npm run scan` (keeps the security/SEO gate in CI)
+  - Production branch (`main`) deploy command: `npm run cloudflare:deploy`
+  - Non-production branch deploy command: `npx wrangler versions upload` (uploads a preview version + `*.workers.dev` preview URL; does **not** run the production pings)
+  - `preview_urls: true` in `wrangler.jsonc` enables the preview URL Workers Builds posts on PRs.
+
+  Neither `websub:ping` nor `webmentions:send` needs a secret, so no build env vars are required. Tracking: GH #26.
 
 ## Worktrees
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ Personal blog. Built with [Anglesite](https://anglesite.dwk.io) (Astro 6 + Markd
 - `npm run lint:css` / `npm run lint:md` — stylelint / markdownlint (advisory)
 - `npm run deploy` — Build + pre-deploy security scan + `wrangler deploy` + WebSub ping + send webmentions
 
+## Worktrees
+
+Prefer a git worktree by default when starting any non-trivial change — a feature, a new post, or a multi-file edit — so work stays isolated from the main checkout. Use the harness's native worktree support, or `git worktree add ../pulletsforever-<branch> -b <branch>`. Each worktree is a fresh checkout with no `node_modules` (it isn't shared across worktrees), so run `npm install` in it before any `npm run build` / `npm test` / `npm run new-post`. Deploy from the main checkout after merging, not from a feature worktree.
+
 ## Architecture
 
 - **Pages and routes**: `src/pages/*.astro` (UI) and `src/pages/**/*.ts` (API endpoints — feeds, llms.txt, .well-known)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "websub:ping": "tsx scripts/ping-websub.ts",
     "websub:ping:dry": "tsx scripts/ping-websub.ts --dry-run",
     "scan": "tsx scripts/pre-deploy-check.ts",
+    "notify": "npm run websub:ping || true; npm run webmentions:send || true",
     "deploy": "npm run build && npm run scan && wrangler deploy && npm run websub:ping && npm run webmentions:send",
     "deploy:preview": "npm run build && wrangler deploy --dry-run",
+    "cloudflare:deploy": "wrangler deploy && npm run notify",
     "cf-typegen": "wrangler types",
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:md": "markdownlint-cli2 'docs/**/*.md' '*.md'"

--- a/src/pages/feed.json.ts
+++ b/src/pages/feed.json.ts
@@ -29,7 +29,7 @@ export async function GET(context: APIContext) {
         id: postUrl,
         url: postUrl,
         title: post.data.title,
-        content_html: renderArticleForFeed(post, origin, heroUrl),
+        content_html: renderArticleForFeed(post, origin),
         date_published: rfc3339(post.data.publishDate),
         tags: filterTagList(post.data.tags),
       };

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -4,7 +4,6 @@
  */
 
 import type { APIContext } from "astro";
-import { getImage } from "astro:assets";
 import { getCollection } from "astro:content";
 import siteConfig from "../site.config.ts";
 import {
@@ -24,20 +23,16 @@ export async function GET(context: APIContext) {
     ? rfc3339(posts[0].data.publishDate)
     : rfc3339(new Date());
 
-  const entries = (
-    await Promise.all(
-      posts.map(async (post) => {
-        const postUrl = `${origin}/${post.id}/`;
-        const heroUrl = post.data.image
-          ? `${origin}${(await getImage({ src: post.data.image, format: "webp", width: 1200 })).src}`
-          : undefined;
-        const articleHtml = renderArticleForFeed(post, origin, heroUrl);
-        const tags = filterTagList(post.data.tags);
-        const categoryTags = tags
-          .map((tag) => `\t\t<category term="${escapeXml(tag)}"/>`)
-          .join("\n");
-        const published = rfc3339(post.data.publishDate);
-        return `\t<entry>
+  const entries = posts
+    .map((post) => {
+      const postUrl = `${origin}/${post.id}/`;
+      const articleHtml = renderArticleForFeed(post, origin);
+      const tags = filterTagList(post.data.tags);
+      const categoryTags = tags
+        .map((tag) => `\t\t<category term="${escapeXml(tag)}"/>`)
+        .join("\n");
+      const published = rfc3339(post.data.publishDate);
+      return `\t<entry>
 \t\t<title>${escapeXml(post.data.title)}</title>
 \t\t<link href="${postUrl}" rel="alternate" type="text/html"/>
 \t\t<id>${postUrl}</id>
@@ -45,9 +40,8 @@ export async function GET(context: APIContext) {
 \t\t<updated>${published}</updated>
 ${categoryTags ? categoryTags + "\n" : ""}\t\t<content type="html">${escapeXml(articleHtml)}</content>
 \t</entry>`;
-      }),
-    )
-  ).join("\n");
+    })
+    .join("\n");
 
   const xml = `<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="${siteConfig.language}">

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -43,11 +43,19 @@ export function absolutizeHtml(html: string, siteOrigin: string): string {
   );
 }
 
-/** Build a post's full article HTML for inclusion in a feed entry. */
+/**
+ * Build a post's full article HTML for inclusion in a feed entry.
+ *
+ * Mirrors the website (`[slug].astro`), which renders only the post
+ * body. The frontmatter `image` is metadata (og:image, JSON-LD,
+ * related-post tiles) — every post that wants a visible hero authors
+ * it as the first inline image in the body. We deliberately do NOT
+ * prepend a hero `<figure>` here: doing so duplicated the image, since
+ * the body already contains it.
+ */
 export function renderArticleForFeed(
   post: Post,
   siteOrigin: string,
-  heroUrl?: string,
 ): string {
   const body = absolutizeHtml(renderPostHtml(post), siteOrigin);
   // Posts with footnotes already include the "-dwk" signature inside
@@ -55,15 +63,7 @@ export function renderArticleForFeed(
   // before the footnote section). Footnote-less posts get it appended
   // here at the end.
   const hasFootnotes = /^\[\^[^\]]+\]:/m.test(post.body ?? "");
-  let html = "";
-  if (heroUrl) {
-    const img = absolutizeHtml(
-      `<img src="${heroUrl}" alt="${post.data.imageAlt ?? ""}">`,
-      siteOrigin,
-    );
-    html += `  <figure class="hero-image">\n    ${img}\n  </figure>\n`;
-  }
-  html += `  ${body}\n`;
+  let html = `  ${body}\n`;
   if (!hasFootnotes) {
     html += `  <p class="signature">-dwk</p>`;
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,9 @@
   "compatibility_date": "2026-02-18",
   "main": "worker/site-entry.ts",
   "upload_source_maps": true,
+  // Enable the *.workers.dev preview URL for non-production branch versions
+  // (Workers Builds posts these on PRs). See CLAUDE.md "Deploying".
+  "preview_urls": true,
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",


### PR DESCRIPTION
## Why

The Cloudflare Workers Builds check is failing on PRs (e.g. #47). I diagnosed it: the PR's code and `wrangler.jsonc` are fine — `npm run build`, `wrangler deploy --dry-run`, and `npm run scan` all pass locally. The failure is that **the CI deploy path was never wired up** (the open work in #26). There was no CI-appropriate deploy command — only the laptop `npm run deploy`, which chains **fatal** WebSub/webmention pings that would mark a build failed on any transient hub error.

## What this adds (code half of #26)

- **`cloudflare:deploy`** = `wrangler deploy && npm run notify` — the command Workers Builds runs on the production branch.
- **`notify`** = `npm run websub:ping || true; npm run webmentions:send || true` — post-deploy pings made **non-fatal**. `scripts/ping-websub.ts` exits 1 on a transient hub rejection; `|| true` keeps an otherwise-successful deploy green while still attempting the pings. A real `wrangler deploy` failure still fails the build (verified: `cmd && notify` only reaches `notify` on deploy success).
- **`preview_urls: true`** in `wrangler.jsonc` for the PR preview URLs Workers Builds posts.
- **CLAUDE.md** documents both deploy paths + the dashboard build/deploy commands.

Verified neither ping script references `process.env` / any token, so **no CI secrets are needed**.

## Decisions (both were open questions in #26)

- **Pings: chained but non-fatal** — keeps #26's intent (auto WebSub/webmention on prod deploy) without flaky red checks.
- **Security scan runs in CI** — dashboard build command is `npm run build && npm run scan`, preserving the gate the laptop flow has. Passes on this branch today.

## Out of scope (the human half of #26 — can't be done from the repo)

One-time Cloudflare dashboard wiring:
- Settings → Builds → connect repo; production branch = `main`
- Build command: `npm run build && npm run scan`
- Production deploy command: `npm run cloudflare:deploy`
- Non-production branch deploy command: `npx wrangler versions upload`
- Authorize the Cloudflare GitHub App

Once that's set, the failing check on #47 (and future PRs) should go green. Refs #26.

## Verification

- `package.json` valid JSON; `cloudflare:deploy` + `notify` registered.
- `npx wrangler deploy --dry-run` passes with `preview_urls` added.
- `markdownlint CLAUDE.md` → 0 errors.
- Shell semantics confirmed: notify pattern exits 0 even if both pings fail; deploy failure still exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)